### PR TITLE
Python3.9 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Updated
+
+* `enva` is now Python 3.9 compatible!
+
 ### Added
 
 * Function decorator to verify env var exists

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the search engine for your codebase.
 
 ## Requirements
 
-* Python 3.10 or greater
+* Python 3.9 or greater
 * That's it
 
 Install enva from pypi with

--- a/enva/checkers.py
+++ b/enva/checkers.py
@@ -1,4 +1,5 @@
 import os
+from typing import Callable
 
 
 def require_variable_exists(variable: str) -> None:
@@ -6,7 +7,7 @@ def require_variable_exists(variable: str) -> None:
         raise RuntimeError(f"{variable} environment variable is not set")
 
 
-def require_variable_as_type(variable: str, type_conversion) -> None:
+def require_variable_as_type(variable: str, type_conversion: Callable) -> None:
     require_variable_exists(variable)
     type_conversion(os.getenv(variable))
 

--- a/enva/getters.py
+++ b/enva/getters.py
@@ -1,8 +1,10 @@
 import os
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, TypeVar, Union
+
+T = TypeVar("T")
 
 
-def get_env_with_fallback(primary_variable: str, secondary_variable: str):
+def get_env_with_fallback(primary_variable: str, secondary_variable: str) -> Union[str, None]:
     """
     Retrieve an environment variable, from a priority list of variables.
 
@@ -100,10 +102,19 @@ def get_env_bool(
 
 
 def _get_env_type_wrapper(
-    variable: str, default_value, conversion_func: Callable, raise_typeerror: bool
-):
+    variable: str,
+    default_value: T,
+    conversion_func: Callable[..., T],
+    raise_typeerror: bool,
+) -> Union[T, None]:
     """
     Wrapper for converting an environment variable to a particular type.
+
+    Raises
+    ------
+    TypeError
+        If env variable cannot be converted by conversion function
+        and errors are allowed to be raised by the function
     """
     retrieved_value = os.getenv(variable, default_value)
 
@@ -115,4 +126,4 @@ def _get_env_type_wrapper(
                 f"{variable} variable is not a valid type. Value: {retrieved_value}"
             )
 
-        return None
+    return None

--- a/enva/getters.py
+++ b/enva/getters.py
@@ -1,4 +1,5 @@
 import os
+from typing import Callable, Optional, Union
 
 
 def get_env_with_fallback(primary_variable: str, secondary_variable: str):
@@ -14,15 +15,17 @@ def get_env_with_fallback(primary_variable: str, secondary_variable: str):
         Otherwise, the value assigned to the given environment variables
         in the prioritised order.
     """
-    if (primary_value := os.getenv(primary_variable)) is not None:
+    primary_value = os.getenv(primary_variable)
+
+    if primary_value is not None:
         return primary_value
     else:
         return os.getenv(secondary_variable)
 
 
 def get_env_int(
-    variable: str, default_int: int | None = None, raise_typeerror: bool = False
-) -> None | int:
+    variable: str, default_int: Optional[int] = None, raise_typeerror: bool = False
+) -> Union[None, int]:
     """
     Get an environment variable and convert to an integer.
 
@@ -49,14 +52,14 @@ def get_env_int(
 
 
 def get_env_float(
-    variable: str, default_float: float | None = None, raise_typeerror: bool = False
-) -> None | float:
+    variable: str, default_float: Optional[float] = None, raise_typeerror: bool = False
+) -> Union[None, float]:
     return _get_env_type_wrapper(variable, default_float, float, raise_typeerror)
 
 
 def get_env_bool(
-    variable: str, default_bool: bool | None = None, raise_typeerror: bool = False
-) -> None | bool:
+    variable: str, default_bool: Optional[bool] = None, raise_typeerror: bool = False
+) -> Union[None, bool]:
     """
     Get an environment variable and convert to an boolean.
 
@@ -97,7 +100,7 @@ def get_env_bool(
 
 
 def _get_env_type_wrapper(
-    variable: str, default_value, conversion_func, raise_typeerror: bool
+    variable: str, default_value, conversion_func: Callable, raise_typeerror: bool
 ):
     """
     Wrapper for converting an environment variable to a particular type.

--- a/enva/getters.py
+++ b/enva/getters.py
@@ -4,7 +4,9 @@ from typing import Callable, Optional, TypeVar, Union
 T = TypeVar("T")
 
 
-def get_env_with_fallback(primary_variable: str, secondary_variable: str) -> Union[str, None]:
+def get_env_with_fallback(
+    primary_variable: str, secondary_variable: str
+) -> Union[str, None]:
     """
     Retrieve an environment variable, from a priority list of variables.
 


### PR DESCRIPTION
Make `enva` python 3.9 compatible.

Why? turns out a lot of codebases still use 3.9, including some of mine.
No functional changes; removes a walrus operator and `|` piping-as-union in type hints